### PR TITLE
description more readable, remove note

### DIFF
--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -13,14 +13,18 @@ log = logging.getLogger('python-versions')
 log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
-LINK = ('https://python-rpm-porting.readthedocs.io/en/latest/applications.html'
-        '#are-shebangs-dragging-you-down-to-python-2')
-TEMPLATE = '''{} require{} both Pythons, i.e. Python 2 and 3.
+INFO_URL = ('https://python-rpm-porting.readthedocs.io/en/latest/applications.html'
+            '#are-shebangs-dragging-you-down-to-python-2')
+BUG_URL = 'https://github.com/fedora-python/task-python-versions/issues'
+TEMPLATE = '''These RPMs require both Python 2 and Python 3:
+{rpms}
 
-Read {} to find more information and possible cause.
+Read the following document to find more information and a possible cause:
+{info_url}
 Or ask at #fedora-python IRC channel for help.
 
-If you think the result is false or intentional, file a bug against TODO.
+If you think the result is false or intentional, file a bug against:
+{bug_url}
 '''
 
 
@@ -155,16 +159,18 @@ def run(koji_build, workdir='.', artifactsdir='artifacts'):
                                outcome)
 
     if bads:
-        s = 's' if len(bads) == 1 else ''
         detail.artifact = os.path.join(artifactsdir, 'output.log')
+        rpms = '\n'.join(bads)
         with open(detail.artifact, 'w') as f:
-            f.write(TEMPLATE.format(','.join(bads), s, LINK))
-        detail.note = '{} require{} Python 2 and 3'.format(', '.join(bads), s)
+            f.write(TEMPLATE.format(rpms=rpms,
+                                    info_url=INFO_URL,
+                                    bug_url=BUG_URL))
+        problems = 'Problematic RPMs:\n' + rpms
     else:
-        detail.note = 'no problems found'
+        problems = 'No problems found.'
 
-    summary = 'python-versions {} for {} ({})'.format(
-              outcome, koji_build, detail.note)
+    summary = 'python-versions {} for {}. {}'.format(
+              outcome, koji_build, problems)
     log.info(summary)
 
     output = check.export_YAML(detail)


### PR DESCRIPTION
This makes task result description a bit more readable (1 RPM per line).
It adds a URL to report issues. It also removes detail.note from
resultsdb, because it seemed unnecessary and also made the field
contents overly long for failures (all RPMs listed).

----

Log [before](https://taskotron-dev.fedoraproject.org/artifacts/all/0b1a62e4-9c73-11e6-bafa-525400d7d6a4/task_output/output.log):
```
389-ds-base-1.3.6.1-1.fc26.aarch64.rpm,389-ds-base-1.3.6.1-1.fc26.armv7hl.rpm,389-ds-base-1.3.6.1-1.fc26.i686.rpm,389-ds-base-1.3.6.1-1.fc26.x86_64.rpm require both Pythons, i.e. Python 2 and 3.

Read https://python-rpm-porting.readthedocs.io/en/latest/applications.html#are-shebangs-dragging-you-down-to-python-2 to find more information and possible cause.
Or ask at #fedora-python IRC channel for help.

If you think the result is false or intentional, file a bug against TODO.
```
And after:
```
These RPMs require both Python 2 and Python 3:
389-ds-base-1.3.6.1-1.fc26.armv7hl.rpm
389-ds-base-1.3.6.1-1.fc26.i686.rpm
389-ds-base-1.3.6.1-1.fc26.x86_64.rpm

Read the following document to find more information and a possible cause:
https://python-rpm-porting.readthedocs.io/en/latest/applications.html#are-shebangs-dragging-you-down-to-python-2
Or ask at #fedora-python IRC channel for help.

If you think the result is false or intentional, file a bug against:
https://github.com/fedora-python/task-python-versions/issues
```
An overly long note in resultsdb is visible [here](https://taskotron-dev.fedoraproject.org/resultsdb/results?testcase_name=dist.python-versions&since=2016-10-27T18:28:14,2016-10-27T18:28:15).
