### PR TITLE
python-multilib-conf does not pull in Python 2

### DIFF
--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -63,6 +63,7 @@ NAME_NOTS = (
     b'python-rpm-macros',
     b'python-srpm-macros',
     b'python-sphinx-locale',
+    b'python-multilib-conf',
 )
 
 WHITELIST = (


### PR DESCRIPTION
This should fix error reported on python3-multilib which depends on this package. The -conf subpackage only install a configuration file into /etc that is shared by both Python 2 and 3 versions of the multilib
library.

I expect this to fix an issue reported on this update: https://bodhi.fedoraproject.org/updates/python-multilib-1.2-1.fc25
I don't see anything else that could be causing the error: https://koji.fedoraproject.org/koji/rpminfo?rpmID=9235373